### PR TITLE
Link google logs to known-logs.md

### DIFF
--- a/data/logs.json
+++ b/data/logs.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "Google",
-      "url": "https://transparencyreport.google.com/https/certificates",
+      "url": "https://github.com/google/certificate-transparency-community-site/blob/master/docs/google/known-logs.md",
       "description": "",
       "logo": "google.svg"
     },


### PR DESCRIPTION
The Transparency Report website does not mention CT logs anymore. known-logs.md links to lists of all logs, including google production logs. It also explains what special logs Google runs.